### PR TITLE
refactor/link-reuse

### DIFF
--- a/src/lib/components/Card.svelte
+++ b/src/lib/components/Card.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-	import { Datetime } from "@components";
+	import Datetime from "./Datetime.svelte";
+	import Link from "./Link.svelte";
 
 	export let title: string;
 	export let href: string | undefined = undefined;
@@ -8,9 +9,9 @@
 
 <article>
 	<header>
-		<a {href}>
+		<Link {href}>
 			<h3>{title}</h3>
-		</a>
+		</Link>
 	</header>
 	<slot />
 	{#if $$slots.footer || date}
@@ -44,9 +45,5 @@
 		gap: var(--space-s);
 		font-size: var(--font-size-1);
 		color: hsl(var(--gray-h) var(--gray-s-700) var(--gray-l-700));
-	}
-
-	a:hover {
-		color: var(--color-primary);
 	}
 </style>

--- a/src/lib/components/Card.svelte
+++ b/src/lib/components/Card.svelte
@@ -9,9 +9,13 @@
 
 <article>
 	<header>
-		<Link {href}>
+		{#if href}
+			<Link {href}>
+				<h3>{title}</h3>
+			</Link>
+		{:else}
 			<h3>{title}</h3>
-		</Link>
+		{/if}
 	</header>
 	<slot />
 	{#if $$slots.footer || date}

--- a/src/lib/components/Footer.svelte
+++ b/src/lib/components/Footer.svelte
@@ -79,6 +79,10 @@
   }
 
   nav ul {
+    --link-color: var(--link-accent-color);
+    --link-color-active: var(--link-accent-color-active);
+    --link-bg-active: var(--link-accent-bg-active);
+
     display: flex;
     flex-wrap: wrap;
     justify-content: center;

--- a/src/lib/components/menu/Menu.svelte
+++ b/src/lib/components/menu/Menu.svelte
@@ -1,73 +1,20 @@
+<script context="module" lang="ts">
+  import type { Readable } from "svelte/store";
+  import type { Page } from "@sveltejs/kit";
+
+  export type MenuContext = Readable<Page>;
+</script>
+
 <script lang="ts">
   import { page } from "$app/stores";  
   import { setContext } from "svelte";
+  import styles from "./menu.module.css";
   
-  export let wide = false;
-  export let border = false;
-  export let spacing: undefined | "equal" = undefined;
-  
-  setContext("page", page);
+  setContext<MenuContext>("page", page);
 </script>
 
-<!--
-  @component
-  Menun Component
-  Wrapper component for navigational links.
-  
-  Usage:
-    ```
-      <Menu>
-        <MenuItem />
-        <MenuItem />
-      </Menu>
-    ```
-    
-  Props:
-  
-    | Name        | type              | default  | description                                                                        |
-    |:------------|:------------------|:---------|:-----------------------------------------------------------------------------------|
-    | wide        | boolean?          | false    | Element will take all the available width.                                         |
-    | noBorder    | boolean?          | false    | Removes the bottom border from element.                                            |
-    
-  Context:
-    - "page": sapper page store;
--->
-<nav class:border class:wide>
-  <ul class:equal-spacing={spacing === "equal"}>
+<nav class={styles["menu-container"]}>
+  <ul class={styles["menu-items"]}>
     <slot />
   </ul>
 </nav>
-
-<style>
-  nav {
-    --navigation-height: 50px;
-  }
-  
-  ul {
-    display: inline-grid;
-    place-items: center;
-    place-content: center start;
-    grid-auto-flow: column;
-    gap: var(--space-s);
-    
-    width: fit-content;
-    height: var(--navigation-height);
-  }
-  
-  .border {
-    border-bottom: var(--border-1);
-  }
-  
-  .wide {
-    width: 100%;
-  }
-  
-  .wide > ul {
-    display: grid;
-    width: 100%;
-  }
-  
-  .equal-spacing {
-    grid-auto-columns: 1fr;
-  }
-</style>

--- a/src/lib/components/menu/MenuItem.svelte
+++ b/src/lib/components/menu/MenuItem.svelte
@@ -1,23 +1,16 @@
-<script lang="ts" context="module">
-  import type { Variant } from "@types";
-</script>
-
 <script lang="ts">
   import { getContext } from "svelte";
+  import Link from "../Link.svelte"; 
   import { active } from "./active";
+  import styles from "./menu.module.css";
+
+  import type { MenuContext } from "./Menu.svelte";
   
   export let href = "";
   export let disabled = false;
-  export let prefetch: true | undefined = undefined;
   export let pattern: RegExp | null = null;
-  export let decorationPosition: "top" | "bottom" = "bottom";
-  export let decorationColor: Variant = "primary";
-  export let decorationSize = "0.2em";
   
-  const page = getContext("page");
-
-  // if no `href` is provided -> link will be disabled
-  $: disabled = href ? disabled : true;
+  const page = getContext<MenuContext>("page");
 </script>
 
 <!--
@@ -41,75 +34,8 @@
     | pattern    | RegExp?           | null      | RegExp literal for matching the active state of the current link.                 |
     | decoration | "top" or "bottom" | "bottom"  | Types of underline for links in active state.                                     |    
 -->
-<li>
-  <a
-    class="menu-item underline-{decorationPosition}"
-    class:disabled
-    tabIndex={disabled ? -1 : undefined}
-    style="--menu-item-decoration-color: var(--color-{decorationColor}); --menu-item-decoration-size: {decorationSize}"
-    {href}
-    use:active={{ current: $page.path, pattern }}
-    sapper:prefetch={prefetch}>
-      <slot />
-  </a>
+<li class={styles["menu-item"]} use:active={{ current: $page.path, pattern }}>
+  <Link {href} {disabled}>
+    <slot />
+  </Link>
 </li>
-
-<style>
-  .menu-item {
-    position: relative;
-
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    height: var(--navigation-height);
-    width: 100%;
-    height: 100%;
-    white-space: nowrap;
-
-    text-decoration: none;
-    color: var(--color-gray-600);
-    text-transform: capitalize;
-    cursor: pointer;
-  }
-  
-  .menu-item:hover {
-    color: var(--color-gray-800);
-  }
-  
-  .menu-item::after {
-    content: "";
-    position: absolute;
-    left: 50%;
-    width: var(--menu-item-decoration-size, 0.2em);
-    height: var(--menu-item-decoration-size, 0.2em);
-    border-radius: 50%;
-    background: var(--color-gray-900);
-    transform-origin: 0 100%;
-    transition: transform 0.25s ease-in-out;
-    transform: scaleY(0);
-  }
-
-  .menu-item.underline-bottom::after {
-    transform-origin: 0 100%;
-    bottom: -50%;
-  }
-  
-  .menu-item.underline-top::after {
-    transform-origin: 100% 0%;
-    top: 0;
-  }
-  
-  li :global(.menu-item[aria-current]) {
-    color: var(--color-gray-900);
-  }
-
-  li :global(.menu-item[aria-current]::after) {
-    transform: scaleY(1);
-  }
-
-  .disabled {
-    pointer-events: none;
-    color: var(--color-gray-300);
-    text-decoration: line-through;
-  }
-</style>

--- a/src/lib/components/menu/active.ts
+++ b/src/lib/components/menu/active.ts
@@ -12,18 +12,19 @@ interface Options {
  * 
  * If the pattern is not provided, the href attribute are compated with the current.
  */
-export function active(node: HTMLAnchorElement, { pattern, current }: Options)  {
-	const href = node.getAttribute("href");
+export function active(node: HTMLLIElement, { pattern, current }: Options)  {
+	const a = node.firstElementChild as HTMLAnchorElement;
+	const href = a.getAttribute("href");
   
 	function update({ pattern, current }: Options): void {
 		if (pattern && pattern instanceof RegExp) {
 			(pattern.test(current))
-				? node.setAttribute("aria-current", "page")
-				: node.removeAttribute("aria-current");
+				? a.setAttribute("aria-current", "page")
+				: a.removeAttribute("aria-current");
 		} else {
 			(!pattern && current === href)
-				? node.setAttribute("aria-current", "page")
-				: node.removeAttribute("aria-current");
+				? a.setAttribute("aria-current", "page")
+				: a.removeAttribute("aria-current");
 		}
 	}
   

--- a/src/lib/components/menu/menu.module.css
+++ b/src/lib/components/menu/menu.module.css
@@ -1,0 +1,47 @@
+.menu-container {
+	--navigation-height: 50px;
+
+	--link-color: var(--link-accent-color);
+  --link-color-active: var(--link-accent-color-active);
+  --link-bg-active: var(--link-accent-bg-active);
+}
+
+.menu-items {
+	display: inline-grid;
+	place-items: center;
+	place-content: center start;
+	grid-auto-flow: column;
+	
+	width: fit-content;
+	height: var(--navigation-height);
+}
+
+.menu-item {
+	position: relative;
+
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	height: var(--navigation-height);
+	width: 100%;
+	height: 100%;
+	white-space: nowrap;
+
+	text-decoration: none;
+	color: var(--color-gray-600);
+	text-transform: capitalize;
+	cursor: pointer;
+
+	padding: var(--space-xs);
+}
+
+.menu-item a[aria-current] {
+	color: var(--link-color-active);
+
+	outline: 1px solid currentColor;
+	outline-offset: 0.2em;
+}
+
+.menu-item a[aria-current]:focus-visible {
+	outline-style: dashed;
+}

--- a/src/lib/styles/theme-dark.css
+++ b/src/lib/styles/theme-dark.css
@@ -31,6 +31,10 @@
     --link-color-active: #B4B8F1;
     --link-bg-active: #3B3562;
 
+    --link-accent-color: #A98635;
+    --link-accent-color-active: #E2B642;
+    --link-accent-bg-active: #49381C;
+
     --gallery-border: hsl(217 26% 35%);
   }
 }
@@ -67,6 +71,10 @@
   --link-color: #7A82E3;
   --link-color-active: #B4B8F1;
   --link-bg-active: #3B3562;
+
+  --link-accent-color: #A98635;
+  --link-accent-color-active: #E2B642;
+  --link-accent-bg-active: #49381C;
 
   --gallery-border: hsl(217 26% 35%);
 }

--- a/src/lib/styles/theme-light.css
+++ b/src/lib/styles/theme-light.css
@@ -31,6 +31,10 @@
     --link-color-active: #48447F;
     --link-bg-active: #B4B8F1;
 
+    --link-accent-color: #8C6D2E;
+    --link-accent-color-active: #5D4822;
+    --link-accent-bg-active: #E2B642;
+
     --gallery-border: hsl(236 69% 83%);
   }
 }
@@ -66,6 +70,10 @@
   --link-color: #6268CA;
   --link-color-active: #48447F;
   --link-bg-active: #B4B8F1;
+
+  --link-accent-color: #8C6D2E;
+  --link-accent-color-active: #5D4822;
+  --link-accent-bg-active: #E2B642;
 
   --gallery-border: hsl(236 69% 83%);
 }


### PR DESCRIPTION
- `<Menu />` internals were  refactored to reuse `<Link />` component instead of writing boilerplate for `<a />` tags;
- `<Card />` use '<Link />` instead;
- `accent` links tokens implemented;

TODO: color tokens for `<Link />` should be done better, need better colors and structure.